### PR TITLE
added play-next plus some minor cleanup

### DIFF
--- a/party/playNextQueue.go
+++ b/party/playNextQueue.go
@@ -1,0 +1,77 @@
+package party
+
+import (
+	"container/list"
+	"fmt"
+)
+
+// PlayNextQueue is a FIFO queue implemented as a list.
+type PlayNextQueue struct {
+	// head of the list is the next song to be pulled off
+	songs *list.List
+}
+
+// AddSong to the back of the PlayNext queue.
+// Error if the song is already in the queue.
+func (pnq *PlayNextQueue) AddSong(sid SongUID) error {
+	if element := pnq.getSong(sid); element != nil {
+		return fmt.Errorf("song already in pnq")
+	}
+
+	pnq.songs.PushBack(sid)
+
+	return nil
+}
+
+// NewPlayNextQueue with empty list
+func NewPlayNextQueue() PlayNextQueue {
+	return PlayNextQueue{
+		songs: list.New(),
+	}
+}
+
+// Pop the top item off the queue. Error if nothing is in the queue
+func (pnq *PlayNextQueue) Pop() (SongUID, error) {
+	if pnq.songs.Len() == 0 {
+		return "", fmt.Errorf("play next queue is empty")
+	}
+
+	// get the head, remove it, then return value
+	front := pnq.songs.Front()
+	val := pnq.songs.Remove(front)
+	return val.(SongUID), nil
+}
+
+// Pull the values in the PlayNextQueue.
+// Returns the next items in play order
+func (pnq PlayNextQueue) Pull() interface{} {
+	if pnq.songs.Len() == 0 {
+		return nil
+	}
+
+	// loop over the list, adding each elem to song
+	var vals []SongUID
+	elem := pnq.songs.Front()
+	for elem != nil {
+		vals = append(vals, elem.Value.(SongUID))
+
+		elem = elem.Next()
+	}
+
+	return vals
+}
+
+// return element with song id, nil if no such element found
+func (pnq PlayNextQueue) getSong(sid SongUID) *list.Element {
+
+	elem := pnq.songs.Front()
+	for elem != nil {
+		if elem.Value.(SongUID) == sid {
+			return elem
+		}
+
+		elem = elem.Next()
+	}
+
+	return nil
+}

--- a/party/playNextQueue_test.go
+++ b/party/playNextQueue_test.go
@@ -1,0 +1,34 @@
+package party_test
+
+import (
+	"github.com/me-next/menext-backend/party"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestPlayNextQueue(t *testing.T) {
+	q := party.NewPlayNextQueue()
+
+	// good add
+	songs := []party.SongUID{"1", "2", "3", "4"}
+	for _, song := range songs {
+		assert.Nil(t, q.AddSong(song))
+	}
+
+	// bad add
+	assert.NotNil(t, q.AddSong("1"))
+
+	// now pop songs off
+	for _, expected := range songs {
+		actual, err := q.Pop()
+		assert.Equal(t, expected, actual)
+		assert.Nil(t, err)
+	}
+
+	// empty pop
+	_, err := q.Pop()
+	assert.NotNil(t, err)
+
+	// add to empty
+	assert.Nil(t, q.AddSong("1"))
+}

--- a/party/playing_test.go
+++ b/party/playing_test.go
@@ -1,0 +1,54 @@
+package party_test
+
+// tests specially for playing
+import (
+	"github.com/me-next/menext-backend/party"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func getCurrentlyPlaying(p *party.Party, ouid party.UserUUID) (
+	party.SongUID, error) {
+	raw, err := p.Pull(ouid, 0)
+	if err != nil {
+		return "", err
+	}
+
+	// convert to map
+	data := raw.(map[string]interface{})
+
+	nowPlayingRaw := data[party.PullPlayingKey]
+	nowPlayingData := nowPlayingRaw.(map[string]interface{})
+
+	currentSong := nowPlayingData[party.KCurrentSongID].(party.SongUID)
+	return currentSong, nil
+}
+
+func TestPlaySongOrderCorrect(t *testing.T) {
+	// behavior is to pull from play-next first then try suggestion
+	// check that it acts this way
+	ouid := party.UserUUID("1")
+
+	p := party.New(ouid, "bob")
+
+	assert.Nil(t, p.PlayNext(ouid, "a"))
+	assert.Nil(t, p.PlayNext(ouid, "b"))
+	assert.Nil(t, p.Suggest(ouid, "c")) // should get played last
+	assert.Nil(t, p.PlayNext(ouid, "d"))
+	assert.Nil(t, p.Suggest(ouid, "e"))
+
+	expecteds := []party.SongUID{"a", "b", "d", "c"}
+
+	for _, expected := range expecteds {
+		actual, err := getCurrentlyPlaying(p, ouid)
+		assert.Nil(t, err)
+		assert.Equal(t, expected, actual)
+
+		// now skip
+		assert.Nil(t, p.SongFinished(ouid, actual))
+	}
+
+	actual, err := getCurrentlyPlaying(p, ouid)
+	assert.Nil(t, err)
+	assert.Equal(t, party.SongUID("e"), actual)
+}

--- a/party/songInfo.go
+++ b/party/songInfo.go
@@ -23,8 +23,8 @@ type NowPlaying struct {
 	playing bool
 }
 
-// CurrentlyPlaying checks if there is a song currently playing
-func (np *NowPlaying) CurrentlyPlaying() bool {
+// CurrentlyHasSong checks if there is a song currently playing
+func (np *NowPlaying) CurrentlyHasSong() bool {
 	return np.nowPlaying != ""
 }
 
@@ -105,7 +105,7 @@ func (np NowPlaying) Data() interface{} {
 		return int64(time.Nanosecond) * t.UnixNano() / int64(time.Millisecond)
 	}
 
-	if np.CurrentlyPlaying() {
+	if np.CurrentlyHasSong() {
 		data[KSongStartTimeMs] = toMs(np.startTime)
 		data[KCurrentTimeMs] = toMs(time.Now())
 		data[KSongPosition] = np.songPos

--- a/party/songInfo_test.go
+++ b/party/songInfo_test.go
@@ -74,7 +74,7 @@ func TestSongInfo(t *testing.T) {
 	assert.WithinDuration(t,
 		startT.Add(100*time.Millisecond),
 		currentT,
-		time.Millisecond*1,
+		time.Millisecond*3,
 		"sometimes the time is a little bit off on this one, thanks GC",
 	)
 }

--- a/party/user.go
+++ b/party/user.go
@@ -40,6 +40,7 @@ const (
 	UserCanSuggestSongPermission    = "Suggest"
 	UserCanChangeVolumePermission   = "Volume"
 	UserCanPlayPausePermission      = "PlayPause"
+	UserCanPlaySongNextPermission   = "PlayNext"
 )
 
 // maps can't be const in go
@@ -50,5 +51,6 @@ var (
 		UserCanVoteSuggestionPermission: "Users can vote on songs in the suggestion queue",
 		UserCanChangeVolumePermission:   "Users can change the music volume",
 		UserCanPlayPausePermission:      "Users can play and pause music",
+		UserCanPlaySongNextPermission:   "User can add a song to playnext",
 	}
 )

--- a/server/queueAPI.go
+++ b/server/queueAPI.go
@@ -143,3 +143,37 @@ func (s *Server) SuggestionClearvote(w http.ResponseWriter, r *http.Request) {
 
 	// exit with OK status code
 }
+
+// AddPlayNext adds a song to play next queue
+// Path is /addPlayNext/{pid}/{uid}/{sid}
+// The client must verify that the song id is good.
+func (s *Server) AddPlayNext(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	uidStr, ufound := vars["uid"]
+	pidStr, pfound := vars["pid"]
+	sidStr, sfound := vars["sid"]
+
+	if !ufound || !pfound || !sfound {
+		urlerror(w)
+		return
+	}
+
+	p, err := s.pm.Party(PartyUUID(pidStr))
+	if err != nil {
+		errMsg := jsonError("no such party")
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write(errMsg)
+
+		return
+	}
+
+	// try to suggest teh song
+	err = p.PlayNext(party.UserUUID(uidStr), party.SongUID(sidStr))
+	if err != nil {
+		errMsg := jsonError("%s", err.Error())
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write(errMsg)
+	}
+
+	// exit with OK status code
+}

--- a/server/server.go
+++ b/server/server.go
@@ -350,6 +350,8 @@ func (s *Server) GetAPI() http.Handler {
 	router.Path("/suggestUp/{pid}/{uid}/{sid}").HandlerFunc(s.SuggestionUpvote).Methods("GET")
 	router.Path("/suggestClearvote/{pid}/{uid}/{sid}").HandlerFunc(s.SuggestionClearvote).Methods("GET")
 
+	router.Path("/addPlayNext/{pid}/{uid}/{sid}").HandlerFunc(s.AddPlayNext).Methods("GET")
+
 	return router
 }
 


### PR DESCRIPTION
#37 #19 

Some notes about the current functionality: 
1. When a song ends new songs are pulled first from the playnext, then from the suggestion queue. Currently songs do not move from the suggestion queue to the playnext queue automatically.
2. A song may be playing while it is in the playnext and suggestion queues
3. There is no unified endpoint for moving a song from the suggestion queue to the playnext queue. 